### PR TITLE
fix for gmc init failing :bug:

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,6 @@
 author: Korbinian Habereder (a.k.a SecretOne)
 co-authors:
   - Jonas Fischer (a.k.a Yleisnero)
-version: v0.5.1
+version: v0.5.2
 includes: 
   - public_config.yaml

--- a/gmc_arg_funcs.py
+++ b/gmc_arg_funcs.py
@@ -205,7 +205,7 @@ def git_init(git_url: str):
         readme.write(f"# {os.path.basename(os.getcwd())}")
     os.system("git init")
     git_magic_add(".")
-    parse_commit_only("initial_added README")
+    parse_commit_only("initial commit_added README")
     os.system("git branch -M master")
     os.system(f"git remote add origin {git_url}")
     os.system("git push -u origin master")

--- a/gmc_core.py
+++ b/gmc_core.py
@@ -11,10 +11,13 @@ def parse_args() -> list:
         while arg := next(arg_iter):
             if (task := gmc_args[arg]) is not None:
                 if task[0]:  # command must have args (e.g. commit message)
-                    tasks.append(Task(task[2], task[1], next(arg_iter)))
+                    try:
+                        tasks.append(Task(task[2], task[1], next(arg_iter)))
+                    except StopIteration:  # needed args were not given
+                        raise Exception(f"Needed args for '{arg}' not given!")
                 else:
                     tasks.append(Task(task[2], task[1]))
-    except StopIteration:  # no more args to parse
+    except StopIteration:  # no more args overall to parse
         pass
     except KeyError as failed_key:
         print(f"Given argument {failed_key} does not exist!")

--- a/scripts/linux_build_n_install
+++ b/scripts/linux_build_n_install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. venv/bin/activate
+. env/bin/activate
 pyinstaller --clean gmc.spec
 deactivate
 cp dist/gmc /usr/local/bin


### PR DESCRIPTION
  reasons:
    - gmc init failed due to invalid parsing of args
  solutions:
    - added exception if invalid amount of args is given

changelog-relevant