### PR TITLE
fix for optional args for commands that don't have any :bug:

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,6 @@
 author: Korbinian Habereder (a.k.a SecretOne)
 co-authors:
   - Jonas Fischer (a.k.a Yleisnero)
-version: v0.7.0
+version: v0.7.1
 includes: 
   - public_config.yaml

--- a/gmc_arg_funcs.py
+++ b/gmc_arg_funcs.py
@@ -132,6 +132,7 @@ def parse_feature_start(feature_name: str):
 
 
 def parse_fix(fix_message: str):
+    print(fix_message)
     finish_bugfix = False
     fix_name, reasons, solutions = fix_message.split("_")
     reasons = [reason.strip() for reason in reasons.split("-")]
@@ -224,25 +225,26 @@ def git_status():
 
 
 # stores functions that shall be executed by gmc; format (needs_args, prio, function)
+# needs_args: in range [0,2] -> [no, yes, optional]
 # prios (from high to low): 4 3 [2] 1 0; 2 is default
 gmc_args = AliasDict(
     {
-        "h": (False, 4, display_help),
-        "v": (False, 4, lambda: print(Config().content["version"])),
-        "p": (False, 0, git_push),
-        "s": (False, 0, git_status),
-        "a": (True, 2, git_magic_add),
-        "na": (False, 3, lambda: flags.update({"na": None})),
-        "fi": (True, 1, parse_fix),
-        "fe": (True, 1, parse_feature),
-        "fs": (True, 3, parse_feature_start),
-        "bs": (True, 3, parse_fix_start),
-        "co": (True, 1, parse_commit_only),
-        "sc": (False, 0, parse_store_credentials),
-        "i": (True, 4, git_init),
-        "r": (True, 2, lambda ref: flags.update({"ref": ref})),
-        "d": (False, 2, lambda: flags.update({"done": None})),
-        "c": (False, 0, lambda: Config().edit()),
+        "h": (0, 4, display_help),
+        "v": (0, 4, lambda: print(Config().content["version"])),
+        "p": (0, 0, git_push),
+        "s": (0, 0, git_status),
+        "a": (0, 2, git_magic_add),
+        "na": (0, 3, lambda: flags.update({"na": None})),
+        "fi": (1, 1, parse_fix),
+        "fe": (1, 1, parse_feature),
+        "fs": (1, 3, parse_feature_start),
+        "bs": (1, 3, parse_fix_start),
+        "co": (1, 1, parse_commit_only),
+        "sc": (0, 0, parse_store_credentials),
+        "i": (1, 4, git_init),
+        "r": (1, 2, lambda ref: flags.update({"ref": ref})),
+        "d": (0, 2, lambda: flags.update({"done": None})),
+        "c": (0, 0, lambda: Config().edit()),
     },
     aliases={
         # help aliases

--- a/gmc_core.py
+++ b/gmc_core.py
@@ -14,7 +14,10 @@ def parse_args() -> list:
                     try:
                         tasks.append(Task(task[2], task[1], next(arg_iter)))
                     except StopIteration:  # needed args were not given
-                        raise Exception(f"Needed args for '{arg}' not given!")
+                        if task[0] == 1:
+                            raise Exception(f"Needed args for '{arg}' not given!")
+                        else:
+                            tasks.append(Task(task[2], task[1], "$d34d$"))
                 else:
                     tasks.append(Task(task[2], task[1]))
     except StopIteration:  # no more args overall to parse

--- a/gmc_helper_classes.py
+++ b/gmc_helper_classes.py
@@ -13,8 +13,11 @@ class Task:
         self._args = " ".join(args) if len(args) != 0 else None
 
     def run(self):
-        if self._args is not None:
-            self._runnable(self._args)
+        if self._args:
+            if "$d34d$" in self._args:
+                self._runnable("")
+            else:
+                self._runnable(self._args)
         else:
             self._runnable()
 
@@ -56,11 +59,15 @@ class AliasDict(dict):
     def infuse_custom_commands(self):
         for command in Config().content["public_config"]["custom_commands"]:
             command_name = list(command.keys())[0]
-            needs_args = False
+            needs_args = 0
             priority = 0
 
             try:
                 needs_args = command[command_name]["needs_args"]
+                if needs_args < 0 or needs_args > 2:
+                    raise ValueError(
+                        f"Needs args must be in [0,2]; check your config for command '{command_name}'"
+                    )
             except KeyError:
                 pass
             try:

--- a/public_config.yaml
+++ b/public_config.yaml
@@ -12,7 +12,7 @@ custom_commands:
       # how high gmc should prioritize your command
       priority: 0 # can be omitted -> defaults to 0
       # wheter your command needs cli args
-      needs_args: false # can be omitted -> defaults to False
+      needs_args: 0 # can be omitted -> defaults to 0 (must be in range [0,2] -> [no, yes, optional])
       exec: "print('henlo am example')"
       help: "Give a little help message to yourself :)" # can be omitted
       show_in_help: false # can be omitted -> defaults to True


### PR DESCRIPTION
  reasons:
    - commands with no args or needed args were handled incorrectly
  solutions:
    - changed handling of optionals to 'fake' d34d arg
    - also added some error handling for optional args

changelog-relevant