### PR TITLE
Release 0.8.2

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,6 @@
 author: Korbinian Habereder (a.k.a SecretOne)
 co-authors:
   - Jonas Fischer (a.k.a Yleisnero)
-version: v0.8.1
+version: v0.8.2
 includes: 
   - public_config.yaml

--- a/gmc_arg_funcs.py
+++ b/gmc_arg_funcs.py
@@ -192,7 +192,7 @@ def parse_commit_only(commit_message: str):
     changes = [change for change in changes if change != ""]
 
     # admit that someone tried that
-    if "done" in flags.keys() or "ref" in flags.keys():
+    if "done" in flags.keys():
         print("Nice try! Though you can't reference or end a flow in a commit only ;)")
 
     # build commit message
@@ -210,6 +210,8 @@ def parse_commit_only(commit_message: str):
             for change in changes[1:]:
                 message += f"{os.linesep}- {change}"
             message += '" '  # end description
+
+    _, message = check_flags(message)
 
     os.system(f"git commit {message}")
 

--- a/gmc_helper_classes.py
+++ b/gmc_helper_classes.py
@@ -82,7 +82,7 @@ class AliasDict(dict):
                         needs_args,
                         priority,
                         (
-                            lambda call_args, command=command[command_name][
+                            lambda call_args=None, command=command[command_name][
                                 "exec"
                             ]: exec(command, None, {"call_args": call_args})
                         ),


### PR DESCRIPTION
  reasons:
    - commands with no args failed because callsArgs were required at execution
  solutions:
    - made callArgs optional
    - allowing referencing for commit only now

changelog-relevant